### PR TITLE
Betaling voor gebruik standaard versus gebruik specificatiedocument

### DIFF
--- a/ch01_Strategie.md
+++ b/ch01_Strategie.md
@@ -689,7 +689,7 @@ betalen voor het standaardisatiedocument, ongeacht het bedrag. Dit is
 wel het huidige business model dat het NEN hanteert voor haar
 normen. Ook in het kader van openheid (zie hoofdstuk 8) is het niet
 verstandig om geld te vragen voor de documenten. 
-oe beperkt het bedrag ook moge zijn, de standaarden worden
+Hoe beperkt het bedrag ook moge zijn, de standaarden worden
 er op zijn minst minder open door. In de praktijk worden dan ook
 regelmatig draft versies van deze standaarden gebruikt, omdat deze nog
 gratis verspreid mogen worden.

--- a/ch01_Strategie.md
+++ b/ch01_Strategie.md
@@ -680,15 +680,16 @@ voor opname op de pas-toe of leg-uit lijst met open standaarden van
 het Forum Standaardisatie.
 
 Andere potentiële opbrengsten zijn gerelateerd aan de standaard
-zelf. Het is mogelijk om geld te vragen voor zowel het downloaden van
-de documenten met specificaties, of het kan gekoppeld worden aan het
-gebruik van de standaard. Beide vormen zijn niet bevorderlijk voor de
-adoptie van de standaard. In de praktijk is veel weerstand tegen het
+zelf. Het is mogelijk om een nominale bijdrage te vragen voor zowel het downloaden van
+de documenten met specificaties, alsook voor het verlenen van een afzonderlijk 
+recht om die specificatiedocumenten vervolgens te mogen kopiëren, aan derden 
+beschikbaar te stellen, en te laten gebruiken. 
+In de praktijk is veel weerstand tegen het
 betalen voor het standaardisatiedocument, ongeacht het bedrag. Dit is
 wel het huidige business model dat het NEN hanteert voor haar
 normen. Ook in het kader van openheid (zie hoofdstuk 8) is het niet
-verstandig om geld te vragen voor de documenten of het gebruik van de
-standaard. Hoe beperkt het bedrag ook moge zijn, de standaarden worden
+verstandig om geld te vragen voor de documenten. 
+oe beperkt het bedrag ook moge zijn, de standaarden worden
 er op zijn minst minder open door. In de praktijk worden dan ook
 regelmatig draft versies van deze standaarden gebruikt, omdat deze nog
 gratis verspreid mogen worden.


### PR DESCRIPTION
Betaling afdwingen voor "gebruik van de standaard" is juridisch enkel mogelijk indien er sprake is van een octrooi. Maar betaling afdwingen vanwege een octrooi is niet toegestaan conform de definitie van "Open Standaard" zoals opgenomen in BOMOS zelf. Daarom tekst aangepast om duidelijk te maken dat het hier enkel gaat om een nominale betaling voor gebruik van het specificatiedocument. 